### PR TITLE
Harden npm plugin

### DIFF
--- a/src/npm/package-manager/common.ts
+++ b/src/npm/package-manager/common.ts
@@ -1,4 +1,4 @@
-import type { Project } from '@xeel-dev/cli/ecosystem-support';
+import type { DependencyType, Project } from '@xeel-dev/cli/ecosystem-support';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -13,5 +13,17 @@ export function findDescription(workspace: Project<'NPM'>) {
     }
   } finally {
     return workspace;
+  }
+}
+
+export function getDependencyType(typeString: string): DependencyType {
+  switch (typeString) {
+    case 'dependencies':
+      return 'PROD';
+    case 'devDependencies':
+      return 'DEV';
+    default:
+      // We explicitly do not support optional, and peer dependencies
+      throw new Error(`Unsupported dependency type: ${typeString}`);
   }
 }

--- a/src/npm/package-manager/pnpm.ts
+++ b/src/npm/package-manager/pnpm.ts
@@ -1,7 +1,7 @@
 import type { Project } from '@xeel-dev/cli/ecosystem-support';
 import { exec, ExecError } from '../../utils/exec.js';
 import { NpmDependency, PackageManagerSupport } from '../index.js';
-import { findDescription } from './common.js';
+import { findDescription, getDependencyType } from './common.js';
 
 export class PnpmPackageManagerSupport implements PackageManagerSupport {
   public packageManager = 'pnpm' as const;
@@ -71,6 +71,13 @@ export class PnpmPackageManagerSupport implements PackageManagerSupport {
         const { stdout } = await exec(`pnpm info ${name} --json`);
         this.packageVersionToDateCache[name] = JSON.parse(stdout).time;
       }
+      let type;
+      try {
+        type = getDependencyType(outdated[name].dependencyType);
+      } catch (e) {
+        continue;
+      }
+
       dependencies.push({
         name,
         current: {
@@ -88,8 +95,7 @@ export class PnpmPackageManagerSupport implements PackageManagerSupport {
           ),
         },
         ecosystem: 'NPM',
-        type:
-          outdated[name].dependencyType === 'devDependencies' ? 'DEV' : 'PROD',
+        type,
       });
     }
 

--- a/src/npm/package-manager/yarn.ts
+++ b/src/npm/package-manager/yarn.ts
@@ -2,7 +2,7 @@ import type { Project } from '@xeel-dev/cli/ecosystem-support';
 import { resolve } from 'node:path';
 import { exec, ExecError } from '../../utils/exec.js';
 import { NpmDependency, PackageManagerSupport } from '../index.js';
-import { findDescription } from './common.js';
+import { findDescription, getDependencyType } from './common.js';
 
 export class YarnPackageManagerSupport implements PackageManagerSupport {
   public packageManager = 'yarn' as const;
@@ -106,10 +106,16 @@ export class YarnPackageManagerSupport implements PackageManagerSupport {
         this.packageDeprecationCache[name] =
           packageInfo.deprecated !== undefined;
       }
+      let type;
+      try {
+        type = getDependencyType(dependency.type);
+      } catch (e) {
+        continue;
+      }
       dependencies.push({
         name,
         ecosystem: 'NPM',
-        type: dependency.type === 'dependencies' ? 'PROD' : 'DEV',
+        type,
         current: {
           version: dependency.current,
           isDeprecated: false,


### PR DESCRIPTION
Ensure that we don't post invalid data from
the npm plugin, and filter out incomplete
dependencies.
Also handle cases where the lockfile and package.json are not colocated.