### PR TITLE
Fix snapshot tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,4 @@ jobs:
         with:
           access: public
           token: ${{ secrets.NPM_TOKEN }}
+          tag: snapshot


### PR DESCRIPTION
The default tag is `latest` - we don't want that for snapshots.